### PR TITLE
Add application3.js pack

### DIFF
--- a/app/javascript/packs/application3.js
+++ b/app/javascript/packs/application3.js
@@ -1,0 +1,17 @@
+// This file is automatically compiled by Webpack, along with any other files
+// present in this directory. You're encouraged to place your actual application logic in
+// a relevant structure within app/javascript and only use these pack files to reference
+// that code so it'll be compiled.
+
+require("@rails/ujs").start()
+// require("turbolinks").start()
+require("@rails/activestorage").start()
+require("channels")
+
+
+// Uncomment to copy all static images under ../images to the output folder and reference
+// them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
+// or the `imagePath` JavaScript helper below.
+//
+// const images = require.context('../images', true)
+// const imagePath = (name) => images(name, true)


### PR DESCRIPTION
Add `application3.js` pack, which is like `application.js` except we comment out `turbolinks` dependency.

The chunks diff is:

```.diff
-application2-d4957a97a589142f36fe.chunk.js
-application~application2-fb178d83c2240eabd029.chunk.js
-application-bacf3572232d201901ce.chunk.js
+application2-9eb5a2f3627847f81086.chunk.js
+application3-82251a99f7da45842714.chunk.js
+application-80c8cf065ea1e15609ff.chunk.js
+application~application2~application3-fb178d83c2240eabd029.chunk.js
 npm.rails-0befccbcb47606b7c19e.chunk.js
-npm.turbolinks-2c262bdfeb090177a24d.chunk.js
-npm.webpack-7742c3022800ae793530.chunk.js
+npm.turbolinks-eeef46ff44962af9ac87.chunk.js
+npm.webpack-effe2dafb80268b54ee2.chunk.js
```